### PR TITLE
feat: add work profile support

### DIFF
--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/App.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.util.Log
 import eu.hxreborn.biometricapplock.prefs.AppOverridesRepository
+import eu.hxreborn.biometricapplock.prefs.Migration
 import eu.hxreborn.biometricapplock.prefs.Prefs
 import eu.hxreborn.biometricapplock.prefs.PrefsRepository
 import eu.hxreborn.biometricapplock.updates.UpdateRepository
@@ -32,6 +33,7 @@ class App :
     override fun onCreate() {
         super.onCreate()
         val localPrefs = getSharedPreferences(Prefs.GROUP, Context.MODE_PRIVATE)
+        Migration.migrateIfNeeded(localPrefs)
         prefsRepository =
             PrefsRepository(localPrefs) {
                 runCatching { boundService?.getRemotePreferences(Prefs.GROUP) }.getOrNull()

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/BiometricAuthActivity.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/BiometricAuthActivity.kt
@@ -2,11 +2,13 @@ package eu.hxreborn.biometricapplock
 
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.LauncherApps
 import android.hardware.biometrics.BiometricManager
 import android.hardware.biometrics.BiometricManager.Authenticators
 import android.hardware.biometrics.BiometricPrompt
 import android.os.Bundle
 import android.os.CancellationSignal
+import android.os.UserManager
 import android.util.Log
 import eu.hxreborn.biometricapplock.prefs.Prefs
 import eu.hxreborn.biometricapplock.util.pickAuthenticators
@@ -35,18 +37,23 @@ open class BiometricAuthActivity : Activity() {
         }
         Log.i(TAG, "gating $targetPkg via=${javaClass.simpleName}")
         val pkg = targetPkg ?: return
+        val userId = intent.getIntExtra(EXTRA_TARGET_USER_ID, 0)
         intent.getStringExtra(EXTRA_TARGET_ACTIVITY)?.let { activity ->
             runCatching {
                 App
                     .from(
                         this,
                     ).appOverridesRepository
-                    .recordRecentActivity(pkg, activity)
+                    .recordRecentActivity("$pkg:$userId", activity)
             }
         }
         val label =
             runCatching {
-                packageManager.getApplicationInfo(pkg, 0).loadLabel(packageManager).toString()
+                val launcherApps = getSystemService(LauncherApps::class.java)
+                val userManager = getSystemService(UserManager::class.java)
+                val userHandle = userManager.getUserForSerialNumber(userId.toLong())
+                val info = launcherApps.getActivityList(pkg, userHandle).firstOrNull()
+                info?.label?.toString() ?: pkg
             }.getOrDefault(pkg)
         showPrompt(getString(R.string.biometric_prompt_unlock_title, label))
     }
@@ -136,7 +143,11 @@ open class BiometricAuthActivity : Activity() {
         val pkg = targetPkg ?: return false
         val token = authToken ?: return false
         // just carries the token back so the hook can resume the real launch
-        val signal = packageManager.getLaunchIntentForPackage(pkg) ?: return false
+        val signal =
+            packageManager.getLaunchIntentForPackage(pkg) ?: Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                setPackage(pkg)
+            }
         signal.putExtra(EXTRA_AUTH_TOKEN, token)
         signal.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION)
         Log.i(TAG, "auth ok, signaling resume pkg=$pkg")
@@ -153,6 +164,7 @@ open class BiometricAuthActivity : Activity() {
         const val OPAQUE_AUTH_ACTIVITY = "$MODULE_PACKAGE.OpaqueAuthActivity"
 
         const val EXTRA_TARGET_PKG = "$MODULE_PACKAGE.TARGET_PKG"
+        const val EXTRA_TARGET_USER_ID = "$MODULE_PACKAGE.TARGET_USER_ID"
         const val EXTRA_AUTH_TOKEN = "$MODULE_PACKAGE.AUTH_TOKEN"
         const val EXTRA_TARGET_ACTIVITY = "$MODULE_PACKAGE.TARGET_ACTIVITY"
 

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/AuthTokenManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/AuthTokenManager.kt
@@ -9,15 +9,20 @@ private const val TOKEN_TTL_MS = 2 * 60 * 1000L
 
 internal class PendingAuth(
     val issuedAt: Long,
+    val packageName: String,
+    val userId: Int,
     val launch: Intent?,
 )
 
 private val pending = ConcurrentHashMap<String, PendingAuth>()
 
-internal fun createToken(): String {
+internal fun createToken(
+    packageName: String,
+    userId: Int = 0,
+): String {
     removeExpiredTokens()
     val token = UUID.randomUUID().toString()
-    pending[token] = PendingAuth(SystemClock.elapsedRealtime(), null)
+    pending[token] = PendingAuth(SystemClock.elapsedRealtime(), packageName, userId, null)
     return token
 }
 
@@ -25,7 +30,9 @@ internal fun stashLaunch(
     token: String,
     intent: Intent,
 ) {
-    pending.computeIfPresent(token) { _, current -> PendingAuth(current.issuedAt, Intent(intent)) }
+    pending.computeIfPresent(token) { _, current ->
+        PendingAuth(current.issuedAt, current.packageName, current.userId, Intent(intent))
+    }
 }
 
 internal fun discardToken(token: String) {

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/BiometricUnlock.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/BiometricUnlock.kt
@@ -19,14 +19,18 @@ import eu.hxreborn.biometricapplock.util.Logger
 internal fun resolveAuthToken(
     intent: Intent?,
     packageName: String?,
+    userId: Int,
 ): PendingAuth? {
     val token = intent?.getStringExtra(BiometricAuthActivity.EXTRA_AUTH_TOKEN) ?: return null
     val pkg = packageName ?: return null
-    if (pkg !in lockedPackages) return null
     val entry = consumeToken(token) ?: return null
+    if (entry.packageName != pkg) {
+        Logger.warn("token package mismatch: expected=${entry.packageName} actual=$pkg")
+        return null
+    }
     intent.removeExtra(BiometricAuthActivity.EXTRA_AUTH_TOKEN)
-    addUnlocked(pkg)
-    Logger.info("unlocked pkg=$pkg")
+    addUnlocked(pkg, entry.userId)
+    Logger.info("unlocked pkg=$pkg user=${entry.userId}")
     return entry
 }
 
@@ -42,7 +46,8 @@ internal fun tryRedirect(
     className: String,
 ): Boolean {
     val reflection = reflection ?: return false
-    val token = createToken()
+    val userId = runCatching { reflection.userIdField.getInt(interceptor) }.getOrDefault(0)
+    val token = createToken(packageName, userId)
 
     val redirected =
         runCatching {
@@ -55,7 +60,13 @@ internal fun tryRedirect(
             val startFlags = reflection.startFlagsField.getInt(interceptor)
 
             val authIntent =
-                buildAuthIntent(packageName, token, shouldUseOpaqueUnlockPrompt(), className)
+                buildAuthIntent(
+                    packageName,
+                    userId,
+                    token,
+                    shouldUseOpaqueUnlockPrompt(),
+                    className,
+                )
             originalIntent?.let { stashLaunch(token, it) }
 
             val resolveArgs =
@@ -82,6 +93,7 @@ internal fun tryRedirect(
             reflection.activityInfoField.set(interceptor, activityInfo)
             reflection.callingPidField.setInt(interceptor, realPid)
             reflection.callingUidField.setInt(interceptor, realUid)
+            reflection.userIdField.setInt(interceptor, 0)
             reflection.resolvedTypeField.set(interceptor, null)
         }.onFailure {
             discardToken(token)
@@ -97,14 +109,18 @@ internal fun tryRedirect(
  * reliable: it holds START_ANY_ACTIVITY and skips background-launch limits, so the exact task comes
  * forward and deep links / non-exported targets land. Post off the lock, mGlobalLock is held upstream.
  */
-internal fun resumeOriginalLaunch(original: Intent) {
+internal fun resumeOriginalLaunch(auth: PendingAuth) {
     val reflection = reflection ?: return
     val atms = atmsRef ?: return
     val handler = reflection.handlerField.get(atms) as? Handler ?: return
     val context = reflection.contextField.get(atms) as? Context ?: return
+    val original = auth.launch ?: return
     val launch = Intent(original).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+    val userHandle = reflection.userHandleOf.invoke(null, auth.userId)
     handler.post {
-        runCatching { context.startActivity(launch) }.onFailure {
+        runCatching {
+            reflection.startActivityAsUser.invoke(context, launch, userHandle)
+        }.onFailure {
             Logger.error(
                 "resume launch failed: ${it.message}",
                 it,
@@ -129,8 +145,9 @@ internal fun postAuthLaunch(
     val handler = reflection.handlerField.get(activityTaskManagerService) as Handler
     val context = reflection.contextField.get(activityTaskManagerService) as Context
 
-    val token = createToken()
-    val intent = buildAuthIntent(entry.packageName, token, shouldUseOpaqueUnlockPrompt())
+    val token = createToken(entry.packageName, entry.userId)
+    val intent =
+        buildAuthIntent(entry.packageName, entry.userId, token, shouldUseOpaqueUnlockPrompt())
 
     handler.post {
         runCatching { context.startActivity(intent) }.onFailure {
@@ -143,6 +160,7 @@ internal fun postAuthLaunch(
 // translucent by default, opaque is the compat fallback for OEMs that cancel the see-through prompt
 private fun buildAuthIntent(
     targetPackageName: String,
+    targetUserId: Int,
     token: String,
     opaque: Boolean,
     className: String? = null,
@@ -155,6 +173,7 @@ private fun buildAuthIntent(
         }
     component = ComponentName(BiometricAuthActivity.MODULE_PACKAGE, authActivity)
     putExtra(BiometricAuthActivity.EXTRA_TARGET_PKG, targetPackageName)
+    putExtra(BiometricAuthActivity.EXTRA_TARGET_USER_ID, targetUserId)
     putExtra(BiometricAuthActivity.EXTRA_AUTH_TOKEN, token)
     if (!className.isNullOrEmpty()) {
         putExtra(BiometricAuthActivity.EXTRA_TARGET_ACTIVITY, className)

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/LockState.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/LockState.kt
@@ -19,7 +19,7 @@ internal var lockedPackages: Set<String> = emptySet()
 
 private fun packageKey(
     pkg: String,
-    userId: Int,
+    userId: Int?,
 ): String = "$pkg:$userId"
 
 // pkg:userId -> elapsedRealtime of last interaction; entry exists iff the pkg is currently considered unlocked
@@ -93,7 +93,7 @@ internal fun clearRuntimeStateForPackage(
 
 internal fun relockOtherPackages(
     keepPkg: String?,
-    userId: Int,
+    userId: Int?,
 ) {
     if (keepPkg == BiometricAuthActivity.MODULE_PACKAGE) return
     val now = SystemClock.elapsedRealtime()

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/LockState.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/LockState.kt
@@ -11,20 +11,30 @@ internal const val RELOCK_DELAY_NEVER = -1
 
 internal data class TaskEntry(
     val packageName: String,
+    val userId: Int,
 )
 
 @Volatile
 internal var lockedPackages: Set<String> = emptySet()
 
-// pkg -> elapsedRealtime of last interaction; entry exists iff the pkg is currently considered unlocked
+private fun packageKey(
+    pkg: String,
+    userId: Int,
+): String = "$pkg:$userId"
+
+// pkg:userId -> elapsedRealtime of last interaction; entry exists iff the pkg is currently considered unlocked
 private val unlockedMap = ConcurrentHashMap<String, Long>()
 
 internal val unlockedPackages: Set<String>
     get() = unlockedMap.keys.toSet()
 
-internal fun isUnlocked(pkg: String): Boolean {
-    val ts = unlockedMap[pkg] ?: return false
-    val delay = getEffectiveRelockDelay(pkg)
+internal fun isUnlocked(
+    pkg: String,
+    userId: Int,
+): Boolean {
+    val key = packageKey(pkg, userId)
+    val ts = unlockedMap[key] ?: return false
+    val delay = getEffectiveRelockDelay(pkg, userId)
     if (delay == RELOCK_DELAY_NEVER) return true
     if (delay == 0) return true
     return SystemClock.elapsedRealtime() - ts < delay * 1000L
@@ -32,43 +42,67 @@ internal fun isUnlocked(pkg: String): Boolean {
 
 internal fun shouldRelockOnTransition(
     pkg: String,
+    userId: Int,
     now: Long,
 ): Boolean {
-    val delay = getEffectiveRelockDelay(pkg)
+    val key = packageKey(pkg, userId)
+    val delay = getEffectiveRelockDelay(pkg, userId)
     if (delay == RELOCK_DELAY_NEVER) return false
     if (delay == 0) return true
-    val ts = unlockedMap[pkg] ?: return true
+    val ts = unlockedMap[key] ?: return true
     return now - ts >= delay * 1000L
 }
 
-internal fun addUnlocked(pkg: String) {
-    unlockedMap[pkg] = SystemClock.elapsedRealtime()
+internal fun addUnlocked(
+    pkg: String,
+    userId: Int,
+) {
+    unlockedMap[packageKey(pkg, userId)] = SystemClock.elapsedRealtime()
 }
 
-internal fun refreshUnlock(pkg: String) {
-    unlockedMap.computeIfPresent(pkg) { _, _ -> SystemClock.elapsedRealtime() }
+internal fun refreshUnlock(
+    pkg: String,
+    userId: Int,
+) {
+    unlockedMap.computeIfPresent(packageKey(pkg, userId)) { _, _ -> SystemClock.elapsedRealtime() }
 }
 
 internal fun clearUnlocked() {
     unlockedMap.clear()
 }
 
-internal fun removeFromUnlocked(pkgs: Set<String>) {
-    pkgs.forEach { unlockedMap.remove(it) }
+internal fun removeFromUnlocked(keys: Set<String>) {
+    keys.forEach { unlockedMap.remove(it) }
 }
 
 internal val taskCache = ConcurrentHashMap<Int, TaskEntry>()
 
-internal fun clearRuntimeStateForPackage(pkg: String) {
-    unlockedMap.remove(pkg)
-    taskCache.entries.removeIf { it.value.packageName == pkg }
+internal fun clearRuntimeStateForPackage(
+    pkg: String,
+    userId: Int? = null,
+) {
+    if (userId != null) {
+        val key = packageKey(pkg, userId)
+        unlockedMap.remove(key)
+        taskCache.entries.removeIf { it.value.packageName == pkg && it.value.userId == userId }
+    } else {
+        unlockedMap.keys.removeIf { it.startsWith("$pkg:") }
+        taskCache.entries.removeIf { it.value.packageName == pkg }
+    }
 }
 
-internal fun relockOtherPackages(keepPkg: String?) {
+internal fun relockOtherPackages(
+    keepPkg: String?,
+    userId: Int,
+) {
     if (keepPkg == BiometricAuthActivity.MODULE_PACKAGE) return
     val now = SystemClock.elapsedRealtime()
-    unlockedMap.entries.removeIf { (pkg, _) ->
-        pkg != keepPkg && shouldRelockOnTransition(pkg, now)
+    val keepKey = keepPkg?.let { packageKey(it, userId) }
+    unlockedMap.entries.removeIf { (key, _) ->
+        if (key == keepKey) return@removeIf false
+        val pkg = key.substringBeforeLast(':')
+        val uid = key.substringAfterLast(':').toIntOrNull() ?: 0
+        shouldRelockOnTransition(pkg, uid, now)
     }
 }
 
@@ -92,18 +126,23 @@ private val appBlockScreenshotsOverrides = ConcurrentHashMap<String, Boolean>()
 
 private val appAllowedActivities = ConcurrentHashMap<String, Set<String>>()
 
-internal fun getEffectiveRelockDelay(pkg: String): Int =
-    appRelockOverrides[pkg] ?: globalRelockDelaySeconds
+internal fun getEffectiveRelockDelay(
+    pkg: String,
+    userId: Int,
+): Int = appRelockOverrides[packageKey(pkg, userId)] ?: globalRelockDelaySeconds
 
-internal fun shouldBlockScreenshots(pkg: String): Boolean =
-    appBlockScreenshotsOverrides[pkg] ?: globalBlockScreenshots
+internal fun shouldBlockScreenshots(
+    pkg: String,
+    userId: Int,
+): Boolean = appBlockScreenshotsOverrides[packageKey(pkg, userId)] ?: globalBlockScreenshots
 
 internal fun isActivityAllowed(
     pkg: String,
+    userId: Int,
     className: String?,
     targetActivity: String?,
 ): Boolean {
-    val allowed = appAllowedActivities[pkg] ?: return false
+    val allowed = appAllowedActivities[packageKey(pkg, userId)] ?: return false
     if (className != null && className in allowed) return true
     return targetActivity != null && targetActivity in allowed
 }
@@ -130,24 +169,24 @@ internal fun loadHookPrefs(prefs: SharedPreferences) {
         if (!key.startsWith("app_override:")) return@forEach
         when {
             key.endsWith(":relock_delay_seconds") -> {
-                val pkg = key.removePrefix("app_override:").removeSuffix(":relock_delay_seconds")
-                appRelockOverrides[pkg] = prefs.getInt(key, 0)
+                val pkgKey = key.removePrefix("app_override:").removeSuffix(":relock_delay_seconds")
+                appRelockOverrides[pkgKey] = prefs.getInt(key, 0)
             }
 
             key.endsWith(":block_screenshots") -> {
-                val pkg = key.removePrefix("app_override:").removeSuffix(":block_screenshots")
-                appBlockScreenshotsOverrides[pkg] = prefs.getBoolean(key, false)
+                val pkgKey = key.removePrefix("app_override:").removeSuffix(":block_screenshots")
+                appBlockScreenshotsOverrides[pkgKey] = prefs.getBoolean(key, false)
             }
 
             key.endsWith(":allowed_activities") -> {
-                val pkg = key.removePrefix("app_override:").removeSuffix(":allowed_activities")
+                val pkgKey = key.removePrefix("app_override:").removeSuffix(":allowed_activities")
                 val activities =
                     prefs
                         .getString(key, "")
                         ?.split('\n')
                         ?.filterTo(mutableSetOf()) { it.isNotBlank() }
                         .orEmpty()
-                if (activities.isNotEmpty()) appAllowedActivities[pkg] = activities
+                if (activities.isNotEmpty()) appAllowedActivities[pkgKey] = activities
             }
         }
     }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerHooks.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerHooks.kt
@@ -215,7 +215,7 @@ private fun XposedModule.hookRecentsLaunch(classLoader: ClassLoader) {
             val taskId = chain.args[2] as? Int
             val entry = taskId?.let { taskCache[it] }
 
-            entry?.let { relockOtherPackages(it.packageName, it.userId) }
+            relockOtherPackages(entry?.packageName, entry?.userId)
 
             if (entry != null && !isUnlocked(entry.packageName, entry.userId)) {
                 val opaque = shouldUseOpaqueUnlockPrompt()
@@ -276,7 +276,7 @@ private fun XposedModule.hookTaskRemoved(classLoader: ClassLoader) {
                 if (!shouldRelockOnTaskRemoved()) return@runCatching
                 val taskId = chain.args.getOrNull(0)?.let { taskIdField.getInt(it) }
                 val entry = taskId?.let { taskCache.remove(it) } ?: return@runCatching
-                removeFromUnlocked(setOf(entry.packageName))
+                removeFromUnlocked(setOf("${entry.packageName}:${entry.userId}"))
                 Logger.debug { "task removed relock pkg=${entry.packageName} taskId=$taskId" }
             }
             result

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerHooks.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerHooks.kt
@@ -121,36 +121,47 @@ private fun XposedModule.hookLaunchIntercept(classLoader: ClassLoader) {
             val intent = chain.args[intentIdx] as? Intent
             val activityInfo = chain.args[actInfoIdx] as? ActivityInfo
             val packageName = activityInfo?.packageName
+            val userId = reflection?.userIdField?.get(chain.thisObject) as? Int ?: 0
 
-            val auth = resolveAuthToken(intent, packageName)
+            val auth = resolveAuthToken(intent, packageName, userId)
             if (auth != null) {
-                val original = auth.launch
-                if (original != null) {
-                    Logger.debug { "resume original pkg=$packageName" }
-                    resumeOriginalLaunch(original)
+                if (auth.launch != null) {
+                    Logger.debug { "resume original pkg=$packageName user=$userId" }
+                    resumeOriginalLaunch(auth)
                     return@intercept true
                 }
                 return@intercept chain.proceed()
             }
 
-            relockOtherPackages(packageName)
+            relockOtherPackages(packageName, userId)
 
             val result = chain.proceed()
             if (result == true) return@intercept true
-            if (packageName == null || packageName !in lockedPackages) return@intercept false
+            val pkgKey = "$packageName:$userId"
+            if (packageName == null || pkgKey !in lockedPackages) return@intercept false
             if (intent?.hasCategory(Intent.CATEGORY_HOME) == true) return@intercept false
-            if (isActivityAllowed(packageName, activityInfo.name, activityInfo.targetActivity)) {
-                Logger.debug { "intercept allowlisted pkg=$packageName comp=${activityInfo.name}" }
+            if (isActivityAllowed(
+                    packageName,
+                    userId,
+                    activityInfo.name,
+                    activityInfo.targetActivity,
+                )
+            ) {
+                Logger.debug {
+                    "intercept allowlisted pkg=$packageName user=$userId comp=${activityInfo.name}"
+                }
                 return@intercept false
             }
-            if (isUnlocked(packageName)) {
-                refreshUnlock(packageName)
-                Logger.debug { "intercept pass pkg=$packageName comp=${activityInfo.name}" }
+            if (isUnlocked(packageName, userId)) {
+                refreshUnlock(packageName, userId)
+                Logger.debug {
+                    "intercept pass pkg=$packageName user=$userId comp=${activityInfo.name}"
+                }
                 return@intercept false
             }
 
             Logger.debug {
-                "intercept gating pkg=$packageName comp=${activityInfo.name} action=${intent?.action}"
+                "intercept gating pkg=$packageName user=$userId comp=${activityInfo.name} action=${intent?.action}"
             }
             tryRedirect(chain.thisObject, packageName, activityInfo.name)
         }
@@ -171,10 +182,12 @@ private fun XposedModule.hookActivityLaunched(classLoader: ClassLoader) {
             val taskInfo = chain.args[0] as? TaskInfo ?: return@intercept chain.proceed()
             val topActivity = taskInfo.topActivity ?: return@intercept chain.proceed()
             val packageName = topActivity.packageName
-            if (packageName in lockedPackages) {
-                taskCache[taskInfo.taskId] = TaskEntry(packageName)
+            val userId = reflection?.taskInfoUserIdField?.get(taskInfo) as? Int ?: 0
+            val pkgKey = "$packageName:$userId"
+            if (pkgKey in lockedPackages) {
+                taskCache[taskInfo.taskId] = TaskEntry(packageName, userId)
                 Logger.debug {
-                    "launched pkg=$packageName taskId=${taskInfo.taskId} top=${topActivity.shortClassName}"
+                    "launched pkg=$packageName user=$userId taskId=${taskInfo.taskId} top=${topActivity.shortClassName}"
                 }
             }
             chain.proceed()
@@ -202,13 +215,15 @@ private fun XposedModule.hookRecentsLaunch(classLoader: ClassLoader) {
             val taskId = chain.args[2] as? Int
             val entry = taskId?.let { taskCache[it] }
 
-            relockOtherPackages(entry?.packageName)
+            entry?.let { relockOtherPackages(it.packageName, it.userId) }
 
-            if (entry != null && !isUnlocked(entry.packageName)) {
+            if (entry != null && !isUnlocked(entry.packageName, entry.userId)) {
                 val opaque = shouldUseOpaqueUnlockPrompt()
                 Logger.debug {
-                    "recents gate pkg=${entry.packageName} taskId=$taskId pid=$callingPid " +
-                        "uid=$callingUid ${recentsGesture(chain.args.getOrNull(3))} " +
+                    "recents gate pkg=${entry.packageName} user=${entry.userId} taskId=$taskId " +
+                        "pid=$callingPid uid=$callingUid ${recentsGesture(
+                            chain.args.getOrNull(3),
+                        )} " +
                         "mode=${if (opaque) "block" else "surface"}"
                 }
                 if (opaque) {
@@ -224,9 +239,9 @@ private fun XposedModule.hookRecentsLaunch(classLoader: ClassLoader) {
                 return@intercept result
             }
             if (entry != null) {
-                refreshUnlock(entry.packageName)
+                refreshUnlock(entry.packageName, entry.userId)
                 Logger.debug {
-                    "recents pass pkg=${entry.packageName} taskId=$taskId " +
+                    "recents pass pkg=${entry.packageName} user=${entry.userId} taskId=$taskId " +
                         recentsGesture(chain.args.getOrNull(3))
                 }
             }
@@ -295,12 +310,18 @@ private fun XposedModule.hookScreenAwake(classLoader: ClassLoader) {
             if (awake == true && unlockedPackages.isNotEmpty()) {
                 // back awake, only relock the ones past their delay
                 val now = SystemClock.elapsedRealtime()
-                val toRelock = unlockedPackages.filter { shouldRelockOnTransition(it, now) }.toSet()
+                val toRelock =
+                    unlockedPackages
+                        .filter { key ->
+                            val pkg = key.substringBeforeLast(':')
+                            val uid = key.substringAfterLast(':').toIntOrNull() ?: 0
+                            shouldRelockOnTransition(pkg, uid, now)
+                        }.toSet()
                 if (toRelock.isNotEmpty()) removeFromUnlocked(toRelock)
                 Logger.debug {
                     val topPkg =
                         runCatching {
-                            reflection?.findTopResumedPackageName(chain.thisObject)
+                            reflection?.findTopResumedPackageKey(chain.thisObject)
                         }.getOrNull()
                     "screen on relocked=${toRelock.size} topPkg=$topPkg"
                 }
@@ -325,11 +346,17 @@ private fun XposedModule.hookFlagSecure(classLoader: ClassLoader) {
             windowStateClass.getDeclaredField("mActivityRecord").apply { isAccessible = true }
         val packageNameField =
             reflection?.activityRecordPackageNameField ?: error("reflection not ready")
+        val userIdField =
+            reflection?.activityRecordUserIdField ?: error("reflection not ready")
         hook(method).intercept { chain ->
             val ar = activityRecordField.get(chain.thisObject) ?: return@intercept chain.proceed()
             val pkg = packageNameField.get(ar) as? String ?: return@intercept chain.proceed()
-            if (pkg in lockedPackages && isUnlocked(pkg) && shouldBlockScreenshots(pkg)) {
-                Logger.debug { "flagsecure force-block pkg=$pkg" }
+            val userId = userIdField.get(ar) as? Int ?: 0
+            val pkgKey = "$pkg:$userId"
+            if (pkgKey in lockedPackages && isUnlocked(pkg, userId) &&
+                shouldBlockScreenshots(pkg, userId)
+            ) {
+                Logger.debug { "flagsecure force-block pkg=$pkg user=$userId" }
                 return@intercept true
             }
             chain.proceed()

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerReflection.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/hook/SystemServerReflection.kt
@@ -62,6 +62,10 @@ internal class SystemServerReflection(
         cl.loadClass("com.android.server.wm.ActivityRecord")
 
     val activityRecordPackageNameField: Field = activityRecordClass.getField("packageName")
+    val activityRecordUserIdField: Field = activityRecordClass.getField("mUserId")
+
+    private val taskInfoClass = cl.loadClass("android.app.TaskInfo")
+    val taskInfoUserIdField: Field = taskInfoClass.getField("userId")
 
     val intentField: Field = activityStartInterceptorClass.getField("mIntent")
     val resolvedInfoField: Field = activityStartInterceptorClass.getField("mRInfo")
@@ -93,6 +97,16 @@ internal class SystemServerReflection(
 
     val activityTaskManagerServiceField: Field = activityTaskSupervisorClass.getField("mService")
     val contextField: Field = activityTaskManagerServiceClass.getField("mContext")
+    val startActivityAsUser: Method by lazy {
+        contextField.type.getMethod(
+            "startActivityAsUser",
+            Intent::class.java,
+            android.os.UserHandle::class.java,
+        )
+    }
+    val userHandleOf: Method by lazy {
+        android.os.UserHandle::class.java.getMethod("of", Int::class.javaPrimitiveType)
+    }
     val handlerField: Field =
         activityTaskManagerServiceClass.getDeclaredField("mH").apply { isAccessible = true }
 
@@ -104,15 +118,20 @@ internal class SystemServerReflection(
     private val packageNameField: Field by lazy {
         getTopResumedActivity.returnType.getField("packageName")
     }
+    private val userIdFieldTop: Field by lazy {
+        getTopResumedActivity.returnType.getField("mUserId")
+    }
     val refreshSecureSurfaceState: Method by lazy {
         rootWindowContainerField.type.getMethod("refreshSecureSurfaceState")
     }
 
-    fun findTopResumedPackageName(activityTaskManagerService: Any): String? {
+    fun findTopResumedPackageKey(activityTaskManagerService: Any): String? {
         val rootWindowContainer =
             rootWindowContainerField.get(activityTaskManagerService) ?: return null
         val topResumedActivityRecord =
             getTopResumedActivity.invoke(rootWindowContainer) ?: return null
-        return packageNameField.get(topResumedActivityRecord) as? String
+        val pkg = packageNameField.get(topResumedActivityRecord) as? String ?: return null
+        val userId = userIdFieldTop.get(topResumedActivityRecord) as? Int ?: 0
+        return "$pkg:$userId"
     }
 }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/prefs/AppOverridesRepository.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/prefs/AppOverridesRepository.kt
@@ -140,12 +140,19 @@ class AppOverridesRepository(
             remove(blockScreenshotsKey(pkg))
         }
 
-    fun prune(installedPackages: Set<String>) {
+    fun prune(installedPackageKeys: Set<String>) {
         val keys = local.all.keys
         val overrideKeys =
             keys.filter { key ->
                 if (!key.startsWith("app_override:")) return@filter false
-                key.removePrefix("app_override:").substringBefore(":") !in installedPackages
+                // app_override:pkg:userId:suffix
+                val pkgPart = key.removePrefix("app_override:")
+                val firstColon = pkgPart.indexOf(':')
+                if (firstColon == -1) return@filter false
+                val secondColon = pkgPart.indexOf(':', firstColon + 1)
+                if (secondColon == -1) return@filter false
+                val packageKey = pkgPart.substring(0, secondColon)
+                packageKey !in installedPackageKeys
             }
         if (overrideKeys.isNotEmpty()) {
             editLocalAndRemote { overrideKeys.forEach { remove(it) } }
@@ -153,7 +160,7 @@ class AppOverridesRepository(
         val recentsKeys =
             keys.filter {
                 it.startsWith("recents:") &&
-                    it.removePrefix("recents:") !in installedPackages
+                    it.removePrefix("recents:") !in installedPackageKeys
             }
         if (recentsKeys.isNotEmpty()) {
             local.edit { recentsKeys.forEach { remove(it) } }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/prefs/Migration.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/prefs/Migration.kt
@@ -1,0 +1,64 @@
+package eu.hxreborn.biometricapplock.prefs
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+internal object Migration {
+    private const val PREF_VERSION = "pref_version"
+    private const val CURRENT_VERSION = 1
+
+    fun migrateIfNeeded(prefs: SharedPreferences) {
+        val version = prefs.getInt(PREF_VERSION, 0)
+        if (version < CURRENT_VERSION) {
+            migrateToMultiUser(prefs)
+            prefs.edit { putInt(PREF_VERSION, CURRENT_VERSION) }
+        }
+    }
+
+    private fun migrateToMultiUser(prefs: SharedPreferences) {
+        val lockedPackagesRaw = prefs.getString(Prefs.LOCKED_PACKAGES.key, "") ?: ""
+        val allEntries = prefs.all
+
+        prefs.edit {
+            if (lockedPackagesRaw.isNotEmpty()) {
+                val migrated =
+                    lockedPackagesRaw.split("|").joinToString("|") { pkg ->
+                        if (pkg.contains(":")) pkg else "$pkg:0"
+                    }
+                if (migrated != lockedPackagesRaw) {
+                    putString(Prefs.LOCKED_PACKAGES.key, migrated)
+                }
+            }
+
+            allEntries.forEach { (key, value) ->
+                when {
+                    key.startsWith("app_override:") -> {
+                        val parts = key.split(":")
+                        if (parts.size == 3) {
+                            val pkg = parts[1]
+                            val suffix = parts[2]
+                            if (!pkg.contains(":")) {
+                                val newKey = "app_override:$pkg:0:$suffix"
+                                when (value) {
+                                    is Int -> putInt(newKey, value)
+                                    is Boolean -> putBoolean(newKey, value)
+                                    is String -> putString(newKey, value)
+                                }
+                                remove(key)
+                            }
+                        }
+                    }
+
+                    key.startsWith("recents:") -> {
+                        val pkg = key.removePrefix("recents:")
+                        if (!pkg.contains(":")) {
+                            val newKey = "recents:$pkg:0"
+                            putString(newKey, value as? String)
+                            remove(key)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/component/LockedAppsList.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/component/LockedAppsList.kt
@@ -1,5 +1,7 @@
 package eu.hxreborn.biometricapplock.ui.component
 
+import android.content.Context
+import android.content.pm.LauncherApps
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,6 +40,7 @@ import androidx.core.graphics.drawable.toBitmap
 import eu.hxreborn.biometricapplock.R
 import eu.hxreborn.biometricapplock.ui.screen.settings.SettingsSectionHeader
 import eu.hxreborn.biometricapplock.ui.theme.Tokens
+import eu.hxreborn.biometricapplock.util.getUserHandle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -121,10 +125,10 @@ private fun FilledContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(Tokens.SpacingSm),
         ) {
-            visible.forEach { pkg ->
+            visible.forEach { key ->
                 AppChip(
-                    pkg = pkg,
-                    onClick = { onAppClick(pkg) },
+                    packageKey = key,
+                    onClick = { onAppClick(key) },
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -141,30 +145,33 @@ private fun FilledContent(
 
 @Composable
 private fun AppChip(
-    pkg: String,
+    packageKey: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val appName by produceState(initialValue = pkg.substringAfterLast('.'), key1 = pkg) {
+    val packageName = remember(packageKey) { packageKey.substringBeforeLast(':') }
+    val userId = remember(packageKey) { packageKey.substringAfterLast(':').toIntOrNull() ?: 0 }
+
+    val appName by produceState(initialValue = packageName.substringAfterLast('.'), key1 = packageKey) {
         value =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    context.packageManager
-                        .getApplicationInfo(pkg, 0)
-                        .loadLabel(context.packageManager)
-                        .toString()
-                }.getOrDefault(pkg.substringAfterLast('.'))
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    val info = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
+                    info?.label?.toString() ?: packageName.substringAfterLast('.')
+                }.getOrDefault(packageName.substringAfterLast('.'))
             }
     }
-    val icon by produceState<ImageBitmap?>(initialValue = null, key1 = pkg) {
+    val icon by produceState<ImageBitmap?>(initialValue = null, key1 = packageKey) {
         value =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    context.packageManager
-                        .getApplicationIcon(pkg)
-                        .toBitmap()
-                        .asImageBitmap()
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    val info = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
+                    info?.getIcon(0)?.toBitmap()?.asImageBitmap()
                 }.getOrNull()
             }
     }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/navigation/Navigation.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/navigation/Navigation.kt
@@ -98,12 +98,12 @@ sealed interface Screen : NavKey {
 
     @Serializable
     data class AppDetail(
-        val packageName: String,
+        val packageKey: String,
     ) : Screen
 
     @Serializable
     data class AllowedActivities(
-        val packageName: String,
+        val packageKey: String,
     ) : Screen
 }
 
@@ -215,17 +215,17 @@ fun MainNavDisplay(
                 }
                 entry<Screen.AppDetail> { appDetail ->
                     AppDetailScreen(
-                        packageName = appDetail.packageName,
+                        packageKey = appDetail.packageKey,
                         onBack = dropUnlessResumed { backStack.removeLastOrNull() },
                         contentPadding = contentPadding,
-                        onNavigateToAllowedActivities = { pkg ->
-                            backStack.add(Screen.AllowedActivities(pkg))
+                        onNavigateToAllowedActivities = { key ->
+                            backStack.add(Screen.AllowedActivities(key))
                         },
                     )
                 }
                 entry<Screen.AllowedActivities> { key ->
                     AllowedActivitiesScreen(
-                        packageName = key.packageName,
+                        packageKey = key.packageKey,
                         onBack = dropUnlessResumed { backStack.removeLastOrNull() },
                         contentPadding = contentPadding,
                     )

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AllowedActivitiesScreen.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AllowedActivitiesScreen.kt
@@ -3,7 +3,9 @@
 
 package eu.hxreborn.biometricapplock.ui.screen
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.LauncherApps
 import android.content.pm.PackageManager
 import android.text.format.DateUtils
 import androidx.compose.foundation.layout.Box
@@ -64,6 +66,7 @@ import eu.hxreborn.biometricapplock.ui.component.ExpandedTitle
 import eu.hxreborn.biometricapplock.ui.component.SectionCard
 import eu.hxreborn.biometricapplock.ui.component.SectionPosition
 import eu.hxreborn.biometricapplock.ui.theme.Tokens
+import eu.hxreborn.biometricapplock.util.getUserHandle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -81,35 +84,44 @@ private fun sectionPosition(
     }
 
 @Composable
-fun rememberLauncherActivities(packageName: String): Set<String> {
-    val pm = LocalContext.current.packageManager
-    return produceState(emptySet<String>(), packageName) {
+fun rememberLauncherActivities(packageKey: String): Set<String> {
+    val context = LocalContext.current
+    val packageName = remember(packageKey) { packageKey.substringBeforeLast(':') }
+    val userId = remember(packageKey) { packageKey.substringAfterLast(':').toIntOrNull() ?: 0 }
+    return produceState(emptySet<String>(), packageKey) {
         value =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    val intent =
-                        Intent(Intent.ACTION_MAIN)
-                            .addCategory(Intent.CATEGORY_LAUNCHER)
-                            .setPackage(packageName)
-                    pm.queryIntentActivities(intent, 0).mapTo(mutableSetOf()) { it.activityInfo.name }
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    launcherApps.getActivityList(packageName, userHandle).mapTo(mutableSetOf()) { it.componentName.className }
                 }.getOrDefault(emptySet())
             }
     }.value
 }
 
 @Composable
-private fun rememberDeclaredActivities(packageName: String): List<String> {
-    val pm = LocalContext.current.packageManager
-    return produceState(emptyList<String>(), packageName) {
+private fun rememberDeclaredActivities(packageKey: String): List<String> {
+    val context = LocalContext.current
+    val packageName = remember(packageKey) { packageKey.substringBeforeLast(':') }
+    val userId = remember(packageKey) { packageKey.substringAfterLast(':').toIntOrNull() ?: 0 }
+    return produceState(emptyList<String>(), packageKey) {
         value =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    pm
-                        .getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
-                        .activities
-                        ?.map { it.name }
-                        ?.sorted()
-                        .orEmpty()
+                    if (userId == 0) {
+                        context.packageManager
+                            .getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
+                            .activities
+                            ?.map { it.name }
+                            ?.sorted()
+                            .orEmpty()
+                    } else {
+                        // For other users, we might only be able to see launcher activities if we are not root or system
+                        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                        val userHandle = getUserHandle(userId)
+                        launcherApps.getActivityList(packageName, userHandle).map { it.componentName.className }.sorted()
+                    }
                 }.getOrDefault(emptyList())
             }
     }.value
@@ -215,7 +227,7 @@ fun LauncherAllowConfirmDialog(
 
 @Composable
 fun AllowedActivitiesScreen(
-    packageName: String,
+    packageKey: String,
     onBack: () -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
@@ -224,14 +236,14 @@ fun AllowedActivitiesScreen(
     val app = App.from(context)
 
     val overrides by app.appOverridesRepository
-        .observe(packageName)
+        .observe(packageKey)
         .collectAsStateWithLifecycle(initialValue = AppOverrides(null, null))
     val recents by app.appOverridesRepository
-        .observeRecentActivities(packageName)
+        .observeRecentActivities(packageKey)
         .collectAsStateWithLifecycle(initialValue = emptyList())
     val allowed = overrides.allowedActivities
-    val launcherActivities = rememberLauncherActivities(packageName)
-    val declared = rememberDeclaredActivities(packageName)
+    val launcherActivities = rememberLauncherActivities(packageKey)
+    val declared = rememberDeclaredActivities(packageKey)
 
     val recentTimes = remember(recents) { recents.associate { it.className to it.lastSeen } }
     val ordered =
@@ -257,7 +269,7 @@ fun AllowedActivitiesScreen(
             return
         }
         app.appOverridesRepository.setAllowedActivities(
-            packageName,
+            packageKey,
             if (allow) allowed + name else allowed - name,
         )
     }
@@ -265,7 +277,7 @@ fun AllowedActivitiesScreen(
     pendingLauncher?.let { name ->
         LauncherAllowConfirmDialog(
             onConfirm = {
-                app.appOverridesRepository.setAllowedActivities(packageName, allowed + name)
+                app.appOverridesRepository.setAllowedActivities(packageKey, allowed + name)
                 pendingLauncher = null
             },
             onDismiss = { pendingLauncher = null },

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AppDetailScreen.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AppDetailScreen.kt
@@ -3,6 +3,8 @@
 
 package eu.hxreborn.biometricapplock.ui.screen
 
+import android.content.Context
+import android.content.pm.LauncherApps
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -64,12 +66,13 @@ import eu.hxreborn.biometricapplock.ui.screen.settings.PreferenceRow
 import eu.hxreborn.biometricapplock.ui.screen.settings.SettingsSectionHeader
 import eu.hxreborn.biometricapplock.ui.theme.Tokens
 import eu.hxreborn.biometricapplock.ui.util.openAppInfo
+import eu.hxreborn.biometricapplock.util.getUserHandle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @Composable
 fun AppDetailScreen(
-    packageName: String,
+    packageKey: String,
     onBack: () -> Unit,
     contentPadding: PaddingValues,
     onNavigateToAllowedActivities: (String) -> Unit,
@@ -77,34 +80,43 @@ fun AppDetailScreen(
 ) {
     val context = LocalContext.current
     val app = App.from(context)
-    val pm = context.packageManager
 
-    val appName by produceState(initialValue = packageName, key1 = packageName) {
-        value =
-            withContext(Dispatchers.IO) {
-                runCatching { pm.getApplicationInfo(packageName, 0).loadLabel(pm).toString() }
-                    .getOrDefault(packageName)
-            }
-    }
+    val packageName = remember(packageKey) { packageKey.substringBeforeLast(':') }
+    val userId = remember(packageKey) { packageKey.substringAfterLast(':').toIntOrNull() ?: 0 }
 
-    val icon by produceState<ImageBitmap?>(initialValue = null, key1 = packageName) {
+    val appName by produceState(initialValue = packageName, key1 = packageKey) {
         value =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    pm.getApplicationIcon(packageName).toBitmap().asImageBitmap()
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    val info = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
+                    info?.label?.toString() ?: packageName
+                }.getOrDefault(packageName)
+            }
+    }
+
+    val icon by produceState<ImageBitmap?>(initialValue = null, key1 = packageKey) {
+        value =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    val info = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
+                    info?.getIcon(0)?.toBitmap()?.asImageBitmap()
                 }.getOrNull()
             }
     }
 
-    val versionName by produceState<String?>(initialValue = null, key1 = packageName) {
+    val versionName by produceState<String?>(initialValue = null, key1 = packageKey) {
         value =
             withContext(Dispatchers.IO) {
-                runCatching { pm.getPackageInfo(packageName, 0).versionName }.getOrNull()
+                runCatching { context.packageManager.getPackageInfo(packageName, 0).versionName }.getOrNull()
             }
     }
 
     val overrides by app.appOverridesRepository
-        .observe(packageName)
+        .observe(packageKey)
         .collectAsStateWithLifecycle(initialValue = AppOverrides(null, null))
 
     val hasOverrides =
@@ -118,7 +130,7 @@ fun AppDetailScreen(
         RelockDelayDialog(
             currentSeconds = overrides.relockDelaySeconds ?: 0,
             onSelect = { seconds ->
-                app.appOverridesRepository.setRelockDelaySeconds(packageName, seconds)
+                app.appOverridesRepository.setRelockDelaySeconds(packageKey, seconds)
                 showRelockDialog = false
             },
             onDismiss = { showRelockDialog = false },
@@ -162,7 +174,7 @@ fun AppDetailScreen(
             item {
                 AppHeaderCard(
                     appName = appName,
-                    packageName = packageName,
+                    packageName = if (userId == 0) packageName else "$packageName (${stringResource(R.string.apps_user_id, userId)})",
                     versionName = versionName,
                     icon = icon,
                 )
@@ -177,9 +189,9 @@ fun AppDetailScreen(
                     summary = null,
                     onClick = {
                         if (hasOverrides) {
-                            app.appOverridesRepository.reset(packageName)
+                            app.appOverridesRepository.reset(packageKey)
                         } else {
-                            app.appOverridesRepository.setRelockDelaySeconds(packageName, 0)
+                            app.appOverridesRepository.setRelockDelaySeconds(packageKey, 0)
                         }
                     },
                     trailing = {
@@ -187,9 +199,9 @@ fun AppDetailScreen(
                             checked = hasOverrides,
                             onCheckedChange = { enabled ->
                                 if (enabled) {
-                                    app.appOverridesRepository.setRelockDelaySeconds(packageName, 0)
+                                    app.appOverridesRepository.setRelockDelaySeconds(packageKey, 0)
                                 } else {
-                                    app.appOverridesRepository.reset(packageName)
+                                    app.appOverridesRepository.reset(packageKey)
                                 }
                             },
                         )
@@ -216,7 +228,7 @@ fun AppDetailScreen(
                         if (hasOverrides) {
                             {
                                 app.appOverridesRepository.setBlockScreenshots(
-                                    packageName,
+                                    packageKey,
                                     overrides.blockScreenshots != true,
                                 )
                             }
@@ -247,7 +259,7 @@ fun AppDetailScreen(
                                 overrides.allowedActivities.size,
                             )
                         },
-                    onClick = { onNavigateToAllowedActivities(packageName) },
+                    onClick = { onNavigateToAllowedActivities(packageKey) },
                 )
             }
 

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AppListScreen.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/AppListScreen.kt
@@ -3,8 +3,13 @@
 package eu.hxreborn.biometricapplock.ui.screen
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.content.pm.LauncherActivityInfo
+import android.content.pm.LauncherApps
 import android.content.pm.PackageManager
+import android.os.UserHandle
+import android.os.UserManager
 import android.util.LruCache
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -106,6 +111,8 @@ import eu.hxreborn.biometricapplock.ui.component.SectionPosition
 import eu.hxreborn.biometricapplock.ui.theme.Tokens
 import eu.hxreborn.biometricapplock.ui.util.openAppInfo
 import eu.hxreborn.biometricapplock.ui.viewmodel.ScopeViewModel
+import eu.hxreborn.biometricapplock.util.getUserHandle
+import eu.hxreborn.biometricapplock.util.getUserId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -118,8 +125,11 @@ import kotlinx.coroutines.withContext
 private data class AppItem(
     val label: String,
     val packageName: String,
+    val userId: Int,
     val isSystem: Boolean,
-)
+) {
+    val key: String get() = "$packageName:$userId"
+}
 
 private data class AppLoadState(
     val apps: List<AppItem>,
@@ -129,29 +139,33 @@ private data class AppLoadState(
 
 @SuppressLint("QueryPermissionsNeeded")
 private suspend fun loadApps(
-    pm: PackageManager,
+    context: Context,
     ownPackage: String,
 ): List<AppItem> =
     withContext(Dispatchers.IO) {
-        val entries =
-            pm
-                .queryIntentActivities(launchableAppsIntent(), 0)
-                .asSequence()
-                .mapNotNull { resolveInfo ->
-                    val appInfo = resolveInfo.activityInfo?.applicationInfo ?: return@mapNotNull null
-                    val packageName = appInfo.packageName
-                    if (packageName == ownPackage) return@mapNotNull null
-                    packageName to appInfo
-                }.distinctBy { it.first }
-                .toList()
+        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
+        val profiles = userManager.userProfiles
+
+        val entries = mutableListOf<Pair<LauncherActivityInfo, Int>>()
+        for (user in profiles) {
+            val userId = getUserId(user)
+            launcherApps.getActivityList(null, user).forEach { info ->
+                if (info.applicationInfo.packageName != ownPackage) {
+                    entries.add(info to userId)
+                }
+            }
+        }
 
         coroutineScope {
             entries
-                .map { (packageName, appInfo) ->
+                .map { (info, userId) ->
                     async {
+                        val appInfo = info.applicationInfo
                         AppItem(
-                            label = appInfo.loadLabel(pm).toString(),
-                            packageName = packageName,
+                            label = info.label.toString(),
+                            packageName = appInfo.packageName,
+                            userId = userId,
                             isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
                         )
                     }
@@ -162,15 +176,22 @@ private suspend fun loadApps(
 private val iconCache = LruCache<String, ImageBitmap>(200)
 
 @Composable
-private fun rememberAppIcon(packageName: String): ImageBitmap? {
-    val pm = LocalContext.current.packageManager
-    return produceState<ImageBitmap?>(initialValue = iconCache.get(packageName), key1 = packageName) {
+private fun rememberAppIcon(
+    packageName: String,
+    userId: Int,
+): ImageBitmap? {
+    val context = LocalContext.current
+    val key = "$packageName:$userId"
+    return produceState<ImageBitmap?>(initialValue = iconCache.get(key), key1 = key) {
         if (value != null) return@produceState
         value =
             withContext(Dispatchers.IO) {
-                runCatching { pm.getApplicationIcon(packageName).toBitmap().asImageBitmap() }
-                    .getOrNull()
-                    ?.also { iconCache.put(packageName, it) }
+                runCatching {
+                    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                    val userHandle = getUserHandle(userId)
+                    val info = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
+                    info?.getIcon(0)?.toBitmap()?.asImageBitmap()
+                }.getOrNull()?.also { iconCache.put(key, it) }
             }
     }.value
 }
@@ -178,7 +199,6 @@ private fun rememberAppIcon(packageName: String): ImageBitmap? {
 @Composable
 private fun rememberInstalledApps(refreshKey: Int): AppLoadState {
     val context = LocalContext.current
-    val pm = context.packageManager
     val ownPackage = context.packageName
 
     return produceState(
@@ -186,7 +206,7 @@ private fun rememberInstalledApps(refreshKey: Int): AppLoadState {
         key1 = refreshKey,
     ) {
         value = AppLoadState(value.apps, isLoading = true, refreshKey = refreshKey)
-        val apps = loadApps(pm, ownPackage)
+        val apps = loadApps(context, ownPackage)
         value = AppLoadState(apps, isLoading = false, refreshKey = refreshKey)
     }.value
 }
@@ -307,7 +327,7 @@ private fun AppRow(
     onNavigateToDetail: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val icon = rememberAppIcon(app.packageName)
+    val icon = rememberAppIcon(app.packageName, app.userId)
 
     SectionCard(
         position = position,
@@ -325,7 +345,15 @@ private fun AppRow(
             Spacer(modifier = Modifier.width(Tokens.PreferenceHorizontalSpacing))
             Column(modifier = Modifier.weight(1f)) {
                 AppLabel(app.label)
-                AppPackage(app.packageName)
+                AppPackage(
+                    if (app.userId ==
+                        0
+                    ) {
+                        app.packageName
+                    } else {
+                        "${app.packageName} (${stringResource(R.string.apps_user_id, app.userId)})"
+                    },
+                )
             }
             if (canToggle && onNavigateToDetail != null) {
                 Spacer(modifier = Modifier.width(Tokens.PreferenceRowTrailingSpacing))
@@ -449,7 +477,6 @@ fun AppListScreen(
 ) {
     val context = LocalContext.current
     val app = App.from(context)
-    val pm = context.packageManager
 
     val scope by viewModel.scope.collectAsStateWithLifecycle()
     val framework by viewModel.framework.collectAsStateWithLifecycle()
@@ -465,7 +492,17 @@ fun AppListScreen(
     LaunchedEffect(refreshKey) {
         val installed =
             withContext(Dispatchers.IO) {
-                pm.getInstalledApplications(0).mapTo(mutableSetOf()) { it.packageName }
+                val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
+                val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+                val profiles = userManager.userProfiles
+                val keys = mutableSetOf<String>()
+                for (user in profiles) {
+                    val userId = getUserId(user)
+                    launcherApps.getActivityList(null, user).forEach { info ->
+                        keys.add("${info.applicationInfo.packageName}:$userId")
+                    }
+                }
+                keys
             }
         app.appOverridesRepository.prune(installed)
     }
@@ -505,8 +542,8 @@ fun AppListScreen(
 
     val selectableScope =
         remember(appState.apps, scope) {
-            val appPackageNames = appState.apps.mapTo(mutableSetOf()) { it.packageName }
-            scope.filterTo(linkedSetOf()) { it in appPackageNames }
+            val appKeys = appState.apps.mapTo(mutableSetOf()) { it.key }
+            scope.filterTo(linkedSetOf()) { it in appKeys }
         }
 
     // snapshot of scope so toggling a row doesn't reorder the visible list
@@ -516,7 +553,7 @@ fun AppListScreen(
     val sortedApps =
         remember(filteredApps, scopeAtScreenOpen) {
             filteredApps.sortedWith(
-                compareByDescending<AppItem> { it.packageName in scopeAtScreenOpen }.thenBy { it.label.lowercase() },
+                compareByDescending<AppItem> { it.key in scopeAtScreenOpen }.thenBy { it.label.lowercase() },
             )
         }
 
@@ -683,7 +720,7 @@ fun AppListScreen(
                         else -> {
                             itemsIndexed(
                                 items = sortedApps,
-                                key = { _, app -> app.packageName },
+                                key = { _, app -> app.key },
                             ) { index, app ->
                                 val position =
                                     when {
@@ -694,13 +731,13 @@ fun AppListScreen(
                                     }
                                 AppRow(
                                     app = app,
-                                    isChecked = app.packageName in scope,
+                                    isChecked = app.key in scope,
                                     canToggle = serviceAvailable,
                                     onCheckedChange = { checked ->
-                                        viewModel.toggleScope(app.packageName, checked)
+                                        viewModel.toggleScope(app.key, checked)
                                     },
                                     position = position,
-                                    onNavigateToDetail = { onNavigateToAppDetail(app.packageName) },
+                                    onNavigateToDetail = { onNavigateToAppDetail(app.key) },
                                 )
                             }
                         }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/DashboardScreen.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/DashboardScreen.kt
@@ -36,10 +36,10 @@ fun DashboardScreen(
     val moduleStatus by viewModel.moduleStatus.collectAsStateWithLifecycle()
     val scope by viewModel.scope.collectAsStateWithLifecycle()
     val serviceLoadEvent by viewModel.serviceLoadEvent.collectAsStateWithLifecycle()
-    val launchablePackageNames = rememberLaunchablePackageNames()
+    val launchablePackageKeys = rememberLaunchablePackageKeys()
     val lockedApps =
-        remember(scope, launchablePackageNames) {
-            scope.filterTo(linkedSetOf()) { it in launchablePackageNames }
+        remember(scope, launchablePackageKeys) {
+            scope.filterTo(linkedSetOf()) { it in launchablePackageKeys }
         }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/LaunchableApps.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/ui/screen/LaunchableApps.kt
@@ -1,38 +1,47 @@
 package eu.hxreborn.biometricapplock.ui.screen
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
+import android.content.pm.LauncherApps
+import android.os.UserManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.platform.LocalContext
+import eu.hxreborn.biometricapplock.util.getUserId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-internal fun launchableAppsIntent(): Intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
-
 @SuppressLint("QueryPermissionsNeeded")
-internal suspend fun loadLaunchablePackageNames(
-    pm: PackageManager,
+internal suspend fun loadLaunchablePackageKeys(
+    context: Context,
     ownPackage: String,
 ): Set<String> =
     withContext(Dispatchers.IO) {
-        pm
-            .queryIntentActivities(launchableAppsIntent(), 0)
-            .asSequence()
-            .mapNotNull { it.activityInfo?.applicationInfo?.packageName }
-            .filterNot { it == ownPackage }
-            .toSet()
+        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
+        val profiles = userManager.userProfiles
+
+        val keys = mutableSetOf<String>()
+        for (user in profiles) {
+            val userId = getUserId(user)
+            launcherApps.getActivityList(null, user).forEach { info ->
+                val pkg = info.applicationInfo.packageName
+                if (pkg != ownPackage) {
+                    keys.add("$pkg:$userId")
+                }
+            }
+        }
+        keys
     }
 
 @Composable
-internal fun rememberLaunchablePackageNames(): Set<String> {
+internal fun rememberLaunchablePackageKeys(): Set<String> {
     val context = LocalContext.current
-    val pm = context.packageManager
     val ownPackage = context.packageName
-    val packageNames by produceState(initialValue = emptySet(), pm, ownPackage) {
-        value = loadLaunchablePackageNames(pm, ownPackage)
+    val packageKeys by produceState(initialValue = emptySet(), context, ownPackage) {
+        value = loadLaunchablePackageKeys(context, ownPackage)
     }
-    return packageNames
+    return packageKeys
 }

--- a/app/src/main/kotlin/eu/hxreborn/biometricapplock/util/UserUtils.kt
+++ b/app/src/main/kotlin/eu/hxreborn/biometricapplock/util/UserUtils.kt
@@ -1,0 +1,20 @@
+package eu.hxreborn.biometricapplock.util
+
+import android.os.UserHandle
+
+fun getUserId(user: UserHandle): Int =
+    runCatching {
+        UserHandle::class.java.getMethod("getIdentifier").invoke(user) as Int
+    }.getOrDefault(0)
+
+fun getUserHandle(userId: Int): UserHandle =
+    runCatching {
+        UserHandle::class.java
+            .getMethod(
+                "of",
+                Int::class.javaPrimitiveType,
+            ).invoke(null, userId) as UserHandle
+    }.getOrElse {
+        val constructor = UserHandle::class.java.getConstructor(Int::class.javaPrimitiveType)
+        constructor.newInstance(userId)
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="apps_snackbar_selection_cleared">Selection cleared</string>
     <string name="apps_snackbar_undo">Undo</string>
     <string name="apps_empty_no_matches">No apps match</string>
+    <string name="apps_user_id">User %1$d</string>
 
     <string name="app_type_system">SYSTEM</string>
     <string name="app_type_user">USER</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
 android.suppressUnsupportedCompileSdk=36
-version.name=1.4.0
+version.name=1.4.0-workprofile
 version.code=1012
 
 module.id=eu.hxreborn.biometricapplock


### PR DESCRIPTION
Add support for work profile.
The app should be cloned to work profile for the unlock prompt to show. No need to configure it or enable in work profile's Lsposed.